### PR TITLE
Consecutive intervals can now be merged 

### DIFF
--- a/include/interval.hpp
+++ b/include/interval.hpp
@@ -75,7 +75,9 @@ template<class T> class Interval {
 
 	bool disjoint(const Interval<T>& other) const
 	{
-		return other.until() < from() || until() < other.from();
+		//consecutive intervals are not considered to be disjoint
+		// eg. [2,3] and [4,5] is not considered disjoint, this can be merged to form [2,5]
+		return (other.until()+1) < from() || (until()+1) < other.from();
 	}
 
 	bool intersects(const Interval<T>& other) const

--- a/include/uni/space.hpp
+++ b/include/uni/space.hpp
@@ -798,7 +798,6 @@ namespace NP {
 					Interval<Time> next_range{std::min(ts_min, rel_min), t_l};
 
 					DM("ts_min = " << ts_min << std::endl <<
-					   "latest_idle = " << latest_idle << std::endl <<
 					   "latest_finish = " <<s.latest_finish_time() << std::endl);
 					DM("=> next range = " << next_range << std::endl);
 
@@ -901,7 +900,6 @@ namespace NP {
 
 					DM("ts_min = " << ts_min << std::endl <<
 					   "rel_min = " << rel_min << std::endl <<
-					   "latest_idle = " << latest_idle << std::endl <<
 					   "latest_finish = " << s.latest_finish_time() << std::endl);
 					DM("=> next range = " << next_range << std::endl);
 

--- a/src/tests/basic.cpp
+++ b/src/tests/basic.cpp
@@ -15,19 +15,28 @@ static const auto inf = Time_model::constants<dtime_t>::infinity();
 TEST_CASE("Intervals") {
 	auto i1 = Interval<dtime_t>{10, 20};
 	auto i2 = Interval<dtime_t>{15, 25};
+	//to check if i1 and  i3 are not disjoint as they are consecutive intervals
 	auto i3 = Interval<dtime_t>{21, 30};
 	auto i4 = Interval<dtime_t>{5,  45};
+	//to check if i1 and i5 are disjoint as they are not consecutive nor are they joint
+	auto i5 = Interval<dtime_t>{22, 30};
 
 	Interval<dtime_t> ivals[]{i1, i2, i3, i4};
 
 	CHECK(i1.intersects(i2));
 	CHECK(i2.intersects(i3));
-	CHECK(i1.disjoint(i3));
+	//to check if i1 and  i3 are not disjoint as they are consecutive intervals
+	CHECK(i1.intersects(i3));
+	//to check if i1 and i5 are disjoint as they are not consecutive nor are they joint
+	CHECK(i1.disjoint(i5));
 
 	for (auto i : ivals)
 		CHECK(i.intersects(i4));
 
 	CHECK(i1.merge(i2).merge(i3) == I(10, 30));
+
+	//to check if i1 and  i3 are not disjoint as they are consecutive intervals
+	CHECK(i1.merge(i3) == I(10,30));	
 
 	CHECK(I(10, 20).intersects(I(10, 20)));
 }


### PR DESCRIPTION
Consecutive intervals such as [2,3] and [4,5] can now be merged into [2,5]. This is done by changing the way in which intervals are found to be disjoint in the interval.hpp file. Consecutive intervals will no longer be considered as disjoint intervals. Additional assertions have been added to basic.cpp in order to check if consecutive intervals can indeed be merged. 
The DM statement in space.hpp was accessing the variable "latest_idle" which does not exist, hence it has been removed. 