### PR TITLE
Minor bug fixed in the reduction_set "earliest_start_time()" function

### DIFF
--- a/include/uni/reduction_set.hpp
+++ b/include/uni/reduction_set.hpp
@@ -143,7 +143,7 @@ namespace NP {
 			}
 
 			Time earliest_start_time() const {
-				return std::max(cpu_availability.min(), (*jobs_by_latest_arrival.begin())->earliest_arrival());
+				return std::max(cpu_availability.min(), (*jobs_by_earliest_arrival.begin())->earliest_arrival());
 			}
 
 			Time earliest_finish_time() const {


### PR DESCRIPTION
The earliest start time for a reduction set is equal to $\max\lbrace A_1^{min},\min\lbrace r^{min}_x~|~J_x\in \mathcal{J}^x\rbrace \rbrace $.