### PR TITLE
Improvements in the CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8.0)
 
-project(NP_schedulabiliy_test VERSION 1.1.0 LANGUAGES CXX)
+project(NP_schedulabiliy_test VERSION 2.1.0 LANGUAGES CXX)
 
 include_directories(include)
 include_directories(lib/include)
@@ -23,11 +23,11 @@ else ()
 endif ()
 
 if (COLLECT_SCHEDULE_GRAPHS)
-    add_definitions(-DCONFIG_COLLECT_SCHEDULE_GRAPH)
+    add_compile_definitions(CONFIG_COLLECT_SCHEDULE_GRAPH)
 elseif (PARALLEL_RUN)
     find_package(TBB REQUIRED)
     set(TBB_LIB TBB::tbb)
-    add_definitions(-DCONFIG_PARALLEL)
+    add_compile_definitions(CONFIG_PARALLEL)
 endif ()
 
 if (USE_JE_MALLOC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,39 +1,44 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8.0)
 
-project(NP_schedulabiliy_test)
-
-option(USE_TBB_MALLOC "Use the Intel TBB scalable memory allocator" ON)
-option(USE_JE_MALLOC "Use the Facebook jemalloc scalable memory allocator" OFF)
-
-option(DEBUG "Enable debugging" OFF)
-
-option(COLLECT_SCHEDULE_GRAPHS "Enable the collection of schedule graphs" OFF)
-
-if (DEBUG)
-    set(CMAKE_BUILD_TYPE Debug)
-else()
-    set(CMAKE_BUILD_TYPE Release)
-endif()
+project(NP_schedulabiliy_test VERSION 1.1.0 LANGUAGES CXX)
 
 include_directories(include)
 include_directories(lib/include)
 
+option(PARALLEL_RUN "Enable parallel run" OFF)
+option(USE_TBB_MALLOC "Use the Intel TBB scalable memory allocator" ON)
+option(USE_JE_MALLOC "Use the Facebook jemalloc scalable memory allocator" OFF)
+option(COLLECT_SCHEDULE_GRAPHS "Enable the collection of schedule graphs" OFF)
+option(DEBUG "Enable debugging" OFF)
+
+if (PARALLEL_RUN AND COLLECT_SCHEDULE_GRAPHS)
+    message(FATAL_ERROR "Parallel run and schedule graph collection cannot be enabled at the same time")
+endif ()
+
+if (DEBUG)
+    set(CMAKE_BUILD_TYPE Debug)
+    message(NOTICE "Debug build")
+else ()
+    set(CMAKE_BUILD_TYPE Release)
+endif ()
+
 if (COLLECT_SCHEDULE_GRAPHS)
-    add_compile_definitions(CONFIG_COLLECT_SCHEDULE_GRAPH)
-endif()
+    add_definitions(-DCONFIG_COLLECT_SCHEDULE_GRAPH)
+elseif (PARALLEL_RUN)
+    find_package(TBB REQUIRED)
+    set(TBB_LIB TBB::tbb)
+    add_definitions(-DCONFIG_PARALLEL)
+endif ()
 
-find_path(TBB_INCLUDE_DIR NAMES tbb/task_scheduler_init.h)
-find_library(TBB_LIB NAMES tbb)
-
-if(USE_JE_MALLOC)
-  find_library(ALLOC_LIB NAMES jemalloc)
-elseif(USE_TBB_MALLOC)
-  find_library(TBB_ALLOC tbbmalloc_proxy)
-endif()
+if (USE_JE_MALLOC)
+    find_library(ALLOC_LIB NAMES jemalloc)
+    message(NOTICE "Using Facebook jemalloc scalable memory allocator")
+elseif (USE_TBB_MALLOC)
+    find_library(ALLOC_LIB tbbmalloc_proxy)
+    message(NOTICE "Using Intel TBB scalable memory allocator")
+endif ()
 
 set(CORE_LIBS ${TBB_LIB} ${ALLOC_LIB})
-
-include_directories(${TBB_INCLUDE_DIR})
 
 file(GLOB TEST_SOURCES "src/tests/*.cpp")
 add_executable(runtests ${TEST_SOURCES} ${SOURCES})

--- a/include/config.h
+++ b/include/config.h
@@ -5,12 +5,6 @@
 // #define DM(x) std::cerr << x
 #define DM(x)
 
-// #define CONFIG_COLLECT_SCHEDULE_GRAPH
-
-#ifndef CONFIG_COLLECT_SCHEDULE_GRAPH
-#define CONFIG_PARALLEL
-#endif
-
 #ifndef NDEBUG
 #define TBB_USE_DEBUG 1
 #endif


### PR DESCRIPTION
Improvements in the CMakeLists options and add conditions for checking conflict in the CMakeLists. Now there is a separate option (`PARALLEL_RUN`) for running code in parallel.