### PR TITLE
bug fixes in the definition of State_ref with GCC

### DIFF
--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -181,7 +181,7 @@ namespace NP {
 #endif
 			private:
 
-			typedef typename State* State_ref;
+			typedef State* State_ref;
 			typedef typename std::forward_list<State_ref> State_refs;
 
 #ifdef CONFIG_PARALLEL

--- a/include/uni/space.hpp
+++ b/include/uni/space.hpp
@@ -172,7 +172,7 @@ namespace NP {
 			typedef Job_set Scheduled;
 
 			typedef std::deque<State> States;
-			typedef typename State* State_ref;
+			typedef State* State_ref;
 			typedef std::unordered_multimap<hash_value_t, State_ref> States_map;
 
 			typedef const Job<Time>* Job_ref;


### PR DESCRIPTION
Fix the compatibility issue with GCC (`error: expected nested-name-specifier before ‘State’`).