### PR TITLE
Fixed schedule graph collection error

### DIFF
--- a/src/nptest.cpp
+++ b/src/nptest.cpp
@@ -200,7 +200,7 @@ static void process_file(const std::string& fname)
 #ifdef CONFIG_COLLECT_SCHEDULE_GRAPH
 			if (want_dot_graph) {
 				std::string dot_name = fname;
-				auto p = is_yaml ? rta_name.find(".yaml") : rta_name.find(".csv");
+				auto p = is_yaml ? dot_name.find(".yaml") : dot_name.find(".csv");
 				if (p != std::string::npos) {
 					dot_name.replace(p, std::string::npos, ".dot");
 					auto out  = std::ofstream(dot_name,  std::ios::out);


### PR DESCRIPTION
In the current project, an error occurs when `CONFIG_COLLECT_SCHEDULE_GRAPH `is enabled as the `rta_name `variable is not defined in the scope. Fixed the naming issue.