### PR TITLE
Changing Set_type from bool to bit for performance improvement

### DIFF
--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -3,134 +3,126 @@
 
 namespace NP {
 
-	class Index_set
-	{
-	public:
-
-		// Using uint8_t to store 8 bits in each byte
-		typedef std::vector<uint8_t> Set_type;
-
-		// new empty job set
-		Index_set() : the_set() {}
-
-		// derive a new set by "cloning" an existing set and adding an index
-		Index_set(const Index_set& from, std::size_t idx)
-				: the_set(std::max(from.the_set.size(), (idx / 8) + 1), 0)
+		class Index_set
 		{
-			// Copy the existing set
-			std::copy(from.the_set.begin(), from.the_set.end(), the_set.begin());
-			set_bit(idx, true);
-		}
+			public:
+			// Using uint8_t to store 8 bits in each byte
+			typedef std::vector<uint8_t> Set_type;
 
-		// create the diff of two job sets (intended for debugging only)
-		Index_set(const Index_set &a, const Index_set &b)
-				: the_set(std::max(a.the_set.size(), b.the_set.size()), 0)
-		{
-			auto limit = std::min(a.the_set.size(), b.the_set.size());
-			for (std::size_t i = 0; i < limit * 8; ++i) {
-				set_bit(i, a.contains(i) ^ b.contains(i));
+			// new empty job set
+			Index_set() : the_set() {}
+
+			// derive a new set by "cloning" an existing set and adding an index
+			Index_set(const Index_set& from, std::size_t idx)
+					: the_set(std::max(from.the_set.size(), (idx / 8) + 1))
+			{
+				std::copy(from.the_set.begin(), from.the_set.end(), the_set.begin());
+				set_bit(idx, true);
 			}
-		}
 
-		bool operator==(const Index_set &other) const
-		{
-			return the_set == other.the_set;
-		}
-
-		bool operator!=(const Index_set &other) const
-		{
-			return the_set != other.the_set;
-		}
-
-		bool contains(std::size_t idx) const
-		{
-			if (idx / 8 >= the_set.size()) {
-				return false;
+			// create the diff of two job sets (intended for debugging only)
+			Index_set(const Index_set &a, const Index_set &b)
+					: the_set(std::max(a.the_set.size(), b.the_set.size()), 0)
+			{
+				auto limit = std::min(a.the_set.size(), b.the_set.size());
+				for (std::size_t i = 0; i < limit; ++i)
+					the_set[i] = a.the_set[i] & ~b.the_set[i];
 			}
-			return get_bit(idx);
-		}
 
-		bool includes(std::vector<std::size_t> indices) const
-		{
-			for (auto i : indices)
-				if (!contains(i))
-					return false;
-			return true;
-		}
+			bool operator==(const Index_set &other) const
+			{
+				return the_set == other.the_set;
+			}
 
-		bool is_subset_of(const Index_set& other) const
-		{
-			for (std::size_t i = 0; i < the_set.size() * 8; i++) {
-				if (contains(i) && !other.contains(i)) {
+			bool operator!=(const Index_set &other) const
+			{
+				return the_set != other.the_set;
+			}
+
+			bool contains(std::size_t idx) const
+			{
+				if (idx / 8 >= the_set.size()) {
 					return false;
 				}
+				return get_bit(idx);
 			}
-			return true;
-		}
 
-		std::size_t size() const
-		{
-			std::size_t count = 0;
-			for (std::size_t i = 0; i < the_set.size() * 8; ++i) {
-				if (contains(i)) {
-					count++;
+			bool includes(std::vector<std::size_t> indices) const
+			{
+				for (auto i : indices)
+					if (!contains(i))
+						return false;
+				return true;
+			}
+
+			bool is_subset_of(const Index_set& other) const
+			{
+				for (std::size_t i = 0; i < the_set.size() * 8; i++)
+					if (contains(i) && !other.contains(i))
+						return false;
+				return true;
+			}
+
+			std::size_t size() const
+			{
+				std::size_t count = 0;
+				for (std::size_t i = 0; i < the_set.size() * 8; ++i)
+					if (contains(i))
+						count++;
+				return count;
+			}
+
+			void add(std::size_t idx)
+			{
+				if (idx / 8 >= the_set.size())
+					the_set.resize((idx / 8) + 1, 0);
+				set_bit(idx, true);
+			}
+
+			friend std::ostream& operator<< (std::ostream& stream,
+			                                 const Index_set& s)
+			{
+				bool first = true;
+				stream << "{";
+				for (std::size_t i = 0; i < s.the_set.size() * 8; ++i) {
+					if (s.contains(i)) {
+						if (!first)
+							stream << ", ";
+						first = false;
+						stream << i;
+					}
+				}
+				stream << "}";
+
+				return stream;
+			}
+
+			private:
+
+			Set_type the_set;
+
+			// Helper functions to set and get individual bits
+			void set_bit(std::size_t idx, bool value)
+			{
+				std::size_t byte_index = idx / 8;
+				std::size_t bit_index = idx % 8;
+				if (value) {
+					the_set[byte_index] |= (1 << bit_index);
+				} else {
+					the_set[byte_index] &= ~(1 << bit_index);
 				}
 			}
-			return count;
-		}
 
-		void add(std::size_t idx)
-		{
-			if (idx / 8 >= the_set.size()) {
-				the_set.resize((idx / 8) + 1, 0);
+			bool get_bit(std::size_t idx) const
+			{
+				std::size_t byte_index = idx / 8;
+				std::size_t bit_index = idx % 8;
+				return the_set[byte_index] & (1 << bit_index);
 			}
-			set_bit(idx, true);
-		}
 
-		friend std::ostream& operator<< (std::ostream& stream,
-										 const Index_set& s)
-		{
-			bool first = true;
-			stream << "{";
-			for (std::size_t i = 0; i < s.the_set.size() * 8; ++i) {
-				if (s.contains(i)) {
-					if (!first)
-						stream << ", ";
-					first = false;
-					stream << i;
-				}
-			}
-			stream << "}";
-
-			return stream;
-		}
-
-	private:
-
-		Set_type the_set;
-
-		// Helper functions to set and get individual bits
-		void set_bit(std::size_t idx, bool value)
-		{
-			std::size_t byte_index = idx / 8;
-			std::size_t bit_index = idx % 8;
-			if (value) {
-				the_set[byte_index] |= (1 << bit_index);
-			} else {
-				the_set[byte_index] &= ~(1 << bit_index);
-			}
-		}
-
-		bool get_bit(std::size_t idx) const
-		{
-			std::size_t byte_index = idx / 8;
-			std::size_t bit_index = idx % 8;
-			return the_set[byte_index] & (1 << bit_index);
-		}
-
-		// no accidental copies
-		Index_set(const Index_set& origin) = delete;
-	};
+			// no accidental copies
+			Index_set(const Index_set& origin) = delete;
+		};
 }
 
 #endif

--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -60,7 +60,7 @@ namespace NP {
 				// Compare each integer in the sets
 				for (std::size_t i = 0; i < the_set.size(); ++i) {
 					// If there are bits set in the current set that are not set in the other set, it's not a subset
-					if (the_set[i]>0 && ((the_set[i] & other.the_set[i]) != the_set[i] || other.size()<=i)) {
+					if (the_set[i]>0 && (other.the_set.size()<=i || (the_set[i] & other.the_set[i]) != the_set[i])) {
 						return false;
 					}
 				}

--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -3,103 +3,134 @@
 
 namespace NP {
 
-		class Index_set
+	class Index_set
+	{
+	public:
+
+		// Using uint8_t to store 8 bits in each byte
+		typedef std::vector<uint8_t> Set_type;
+
+		// new empty job set
+		Index_set() : the_set() {}
+
+		// derive a new set by "cloning" an existing set and adding an index
+		Index_set(const Index_set& from, std::size_t idx)
+				: the_set(std::max(from.the_set.size(), (idx / 8) + 1), 0)
 		{
-			public:
+			// Copy the existing set
+			std::copy(from.the_set.begin(), from.the_set.end(), the_set.begin());
+			set_bit(idx, true);
+		}
 
-			typedef std::vector<bool> Set_type;
-
-			// new empty job set
-			Index_set() : the_set() {}
-
-			// derive a new set by "cloning" an existing set and adding an index
-			Index_set(const Index_set& from, std::size_t idx)
-			: the_set(std::max(from.the_set.size(), idx + 1))
-			{
-				std::copy(from.the_set.begin(), from.the_set.end(), the_set.begin());
-				the_set[idx] = true;
+		// create the diff of two job sets (intended for debugging only)
+		Index_set(const Index_set &a, const Index_set &b)
+				: the_set(std::max(a.the_set.size(), b.the_set.size()), 0)
+		{
+			auto limit = std::min(a.the_set.size(), b.the_set.size());
+			for (std::size_t i = 0; i < limit * 8; ++i) {
+				set_bit(i, a.contains(i) ^ b.contains(i));
 			}
+		}
 
-			// create the diff of two job sets (intended for debugging only)
-			Index_set(const Index_set &a, const Index_set &b)
-			: the_set(std::max(a.the_set.size(), b.the_set.size()), true)
-			{
-				auto limit = std::min(a.the_set.size(), b.the_set.size());
-				for (unsigned int i = 0; i < limit; i++)
-					the_set[i] = a.contains(i) ^ b.contains(i);
+		bool operator==(const Index_set &other) const
+		{
+			return the_set == other.the_set;
+		}
+
+		bool operator!=(const Index_set &other) const
+		{
+			return the_set != other.the_set;
+		}
+
+		bool contains(std::size_t idx) const
+		{
+			if (idx / 8 >= the_set.size()) {
+				return false;
 			}
+			return get_bit(idx);
+		}
 
-			bool operator==(const Index_set &other) const
-			{
-				return the_set == other.the_set;
+		bool includes(std::vector<std::size_t> indices) const
+		{
+			for (auto i : indices)
+				if (!contains(i))
+					return false;
+			return true;
+		}
+
+		bool is_subset_of(const Index_set& other) const
+		{
+			for (std::size_t i = 0; i < the_set.size() * 8; i++) {
+				if (contains(i) && !other.contains(i)) {
+					return false;
+				}
 			}
+			return true;
+		}
 
-			bool operator!=(const Index_set &other) const
-			{
-				return the_set != other.the_set;
+		std::size_t size() const
+		{
+			std::size_t count = 0;
+			for (std::size_t i = 0; i < the_set.size() * 8; ++i) {
+				if (contains(i)) {
+					count++;
+				}
 			}
+			return count;
+		}
 
-			bool contains(std::size_t idx) const
-			{
-				return the_set.size() > idx && the_set[idx];
+		void add(std::size_t idx)
+		{
+			if (idx / 8 >= the_set.size()) {
+				the_set.resize((idx / 8) + 1, 0);
 			}
+			set_bit(idx, true);
+		}
 
-			bool includes(std::vector<std::size_t> indices) const
-			{
-				for (auto i : indices)
-					if (!contains(i))
-						return false;
-				return true;
+		friend std::ostream& operator<< (std::ostream& stream,
+										 const Index_set& s)
+		{
+			bool first = true;
+			stream << "{";
+			for (std::size_t i = 0; i < s.the_set.size() * 8; ++i) {
+				if (s.contains(i)) {
+					if (!first)
+						stream << ", ";
+					first = false;
+					stream << i;
+				}
 			}
+			stream << "}";
 
-			bool is_subset_of(const Index_set& other) const
-			{
-				for (unsigned int i = 0; i < the_set.size(); i++)
-					if (contains(i) && !other.contains(i))
-						return false;
-				return true;
+			return stream;
+		}
+
+	private:
+
+		Set_type the_set;
+
+		// Helper functions to set and get individual bits
+		void set_bit(std::size_t idx, bool value)
+		{
+			std::size_t byte_index = idx / 8;
+			std::size_t bit_index = idx % 8;
+			if (value) {
+				the_set[byte_index] |= (1 << bit_index);
+			} else {
+				the_set[byte_index] &= ~(1 << bit_index);
 			}
+		}
 
-			std::size_t size() const
-			{
-				std::size_t count = 0;
-				for (auto x : the_set)
-					if (x)
-						count++;
-				return count;
-			}
+		bool get_bit(std::size_t idx) const
+		{
+			std::size_t byte_index = idx / 8;
+			std::size_t bit_index = idx % 8;
+			return the_set[byte_index] & (1 << bit_index);
+		}
 
-			void add(std::size_t idx)
-			{
-				if (idx >= the_set.size())
-					the_set.resize(idx + 1);
-				the_set[idx] = true;
-			}
-
-			friend std::ostream& operator<< (std::ostream& stream,
-			                                 const Index_set& s)
-			{
-				bool first = true;
-				stream << "{";
-				for (auto i = 0; i < s.the_set.size(); i++)
-					if (s.the_set[i]) {
-						if (!first)
-							stream << ", ";
-						first = false;
-						stream << i;
-					}
-				stream << "}";
-
-				return stream;
-			}
-
-			private:
-
-			Set_type the_set;
-
-			// no accidental copies
-			Index_set(const Index_set& origin) = delete;
-		};
+		// no accidental copies
+		Index_set(const Index_set& origin) = delete;
+	};
 }
 
 #endif

--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -6,15 +6,15 @@ namespace NP {
 		class Index_set
 		{
 			public:
-			// Using uint8_t to store 8 bits in each byte
-			typedef std::vector<uint8_t> Set_type;
+			// Using uint64_t to store 64 bits in each byte
+			typedef std::vector<uint64_t> Set_type;
 
 			// new empty job set
 			Index_set() : the_set() {}
 
 			// derive a new set by "cloning" an existing set and adding an index
 			Index_set(const Index_set& from, std::size_t idx)
-					: the_set(std::max(from.the_set.size(), (idx / 8) + 1))
+					: the_set(std::max(from.the_set.size(), (idx / 64) + 1))
 			{
 				std::copy(from.the_set.begin(), from.the_set.end(), the_set.begin());
 				set_bit(idx, true);
@@ -41,7 +41,7 @@ namespace NP {
 
 			bool contains(std::size_t idx) const
 			{
-				if (idx / 8 >= the_set.size()) {
+				if (idx / 64 >= the_set.size()) {
 					return false;
 				}
 				return get_bit(idx);
@@ -57,7 +57,7 @@ namespace NP {
 
 			bool is_subset_of(const Index_set& other) const
 			{
-				for (std::size_t i = 0; i < the_set.size() * 8; i++)
+				for (std::size_t i = 0; i < the_set.size() * 64; i++)
 					if (contains(i) && !other.contains(i))
 						return false;
 				return true;
@@ -66,7 +66,7 @@ namespace NP {
 			std::size_t size() const
 			{
 				std::size_t count = 0;
-				for (std::size_t i = 0; i < the_set.size() * 8; ++i)
+				for (std::size_t i = 0; i < the_set.size() * 64; ++i)
 					if (contains(i))
 						count++;
 				return count;
@@ -74,8 +74,8 @@ namespace NP {
 
 			void add(std::size_t idx)
 			{
-				if (idx / 8 >= the_set.size())
-					the_set.resize((idx / 8) + 1, 0);
+				if (idx / 64 >= the_set.size())
+					the_set.resize((idx / 64) + 1, 0);
 				set_bit(idx, true);
 			}
 
@@ -84,7 +84,7 @@ namespace NP {
 			{
 				bool first = true;
 				stream << "{";
-				for (std::size_t i = 0; i < s.the_set.size() * 8; ++i) {
+				for (std::size_t i = 0; i < s.the_set.size() * 64; ++i) {
 					if (s.contains(i)) {
 						if (!first)
 							stream << ", ";
@@ -104,8 +104,8 @@ namespace NP {
 			// Helper functions to set and get individual bits
 			void set_bit(std::size_t idx, bool value)
 			{
-				std::size_t byte_index = idx / 8;
-				std::size_t bit_index = idx % 8;
+				std::size_t byte_index = idx / 64;
+				std::size_t bit_index = idx % 64;
 				if (value) {
 					the_set[byte_index] |= (1 << bit_index);
 				} else {
@@ -115,8 +115,8 @@ namespace NP {
 
 			bool get_bit(std::size_t idx) const
 			{
-				std::size_t byte_index = idx / 8;
-				std::size_t bit_index = idx % 8;
+				std::size_t byte_index = idx / 64;
+				std::size_t bit_index = idx % 64;
 				return the_set[byte_index] & (1 << bit_index);
 			}
 

--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -57,9 +57,19 @@ namespace NP {
 
 			bool is_subset_of(const Index_set& other) const
 			{
-				for (std::size_t i = 0; i < the_set.size() * 64; i++)
-					if (contains(i) && !other.contains(i))
+				// If the current set has more integers than the other set, it can't be a subset.
+				if (the_set.size() > other.the_set.size()) {
+					return false;
+				}
+
+				// Compare each integer in the sets
+				for (std::size_t i = 0; i < the_set.size(); ++i) {
+					// If there are bits set in the current set that are not set in the other set, it's not a subset
+					if ((the_set[i] & other.the_set[i]) != the_set[i]) {
 						return false;
+					}
+				}
+
 				return true;
 			}
 

--- a/include/index_set.hpp
+++ b/include/index_set.hpp
@@ -57,15 +57,10 @@ namespace NP {
 
 			bool is_subset_of(const Index_set& other) const
 			{
-				// If the current set has more integers than the other set, it can't be a subset.
-				if (the_set.size() > other.the_set.size()) {
-					return false;
-				}
-
 				// Compare each integer in the sets
 				for (std::size_t i = 0; i < the_set.size(); ++i) {
 					// If there are bits set in the current set that are not set in the other set, it's not a subset
-					if ((the_set[i] & other.the_set[i]) != the_set[i]) {
+					if (the_set[i]>0 && ((the_set[i] & other.the_set[i]) != the_set[i] || other.size()<=i)) {
 						return false;
 					}
 				}


### PR DESCRIPTION
In our performance testing of the previous `Index_set` implementation using `std::vector<bool>` on Linux (GCC versions 11.4 and 12.3), we observed significantly higher runtime compared to MSVC on Windows.

To quantify the difference, we ran experiments on 200 task sets for a system with 4 cores on a server equipped with Red Hat 9.4 and AMD Rome 7H12 processors clocked at 2.6 GHz. The results showed that the previous implementation had an average runtime of 41.2 seconds and consumed 29.83 MB of memory. In contrast, the updated implementation, which replaces `bool` with bits using `std::vector<uint8_t>`, achieved an average runtime of just 0.678 seconds, with a slightly higher memory consumption of 30.22 MB.